### PR TITLE
feat: add CI/CD workflow for Jekyll site

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,69 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Runs on pull request events targeting the default branch
+  pull_request:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        with:
+          ruby-version: '3.2' # Updated to Ruby 3.2
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        # Automatically uploads an artifact from the './_site' directory by default
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
This pull request introduces a CI/CD workflow for our Jekyll site, ensuring automatic building and deployment to GitHub Pages.

Workflow Details
Event Triggers:

- Runs on pushes to the master branch.
- Runs on pull request events targeting the master branch.
- Allows manual triggers from the Actions tab.

Permissions:

GITHUB_TOKEN permissions are set to allow read and write access to contents and GitHub Pages.
Concurrency:

Ensures only one deployment is in progress at any given time without canceling in-progress deployments.
Jobs:

Build Job:

- Checks out the repository.
- Sets up Ruby environment with caching for gems.
- Configures Pages and builds the site using Jekyll.
- Uploads the built site as an artifact.

Deploy Job:

- Deploys the built Jekyll site to GitHub Pages.
- This automated workflow ensures that every change pushed or merged into the master branch is built and deployed seamlessly, improving our deployment efficiency and reliability.

How to Test

- Verify that the workflow triggers on push and pull request events targeting the master branch.
- Check the Actions tab to manually trigger the workflow if needed.
- Ensure successful build and deployment to GitHub Pages.