### PR TITLE
ci: run build job on PRs and deploy only on main branch

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -57,6 +57,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
- Updated GitHub Actions workflow to run the build job on pull requests targeting the main branch.
- Modified the deploy job to run only when changes are pushed to the main branch.
- Ensures that deployment does not occur during pull requests, but builds are still validated.